### PR TITLE
simplify window positioning; add "fast nudge" hotkey on ctrl

### DIFF
--- a/Photobooth/Controls/Editor.cs
+++ b/Photobooth/Controls/Editor.cs
@@ -45,6 +45,29 @@ public unsafe ref struct Editor
         };
     }
 
+    public static unsafe AddonBannerEditor* GetAddon()
+    {
+        return (AddonBannerEditor*)Plugin.GameGui.GetAddonByName("BannerEditor");
+    }
+
+    public static bool IsAddonOpen()
+    {
+        var a = GetAddon();
+        return a != null && a->IsVisible;
+    }
+
+    public static bool IsAddonReady()
+    {
+        var a = GetAddon();
+        var e = Current();
+
+        return e.IsValid & a != null
+            && a->IsVisible
+            && a->IsReady
+            && a->IsFullyLoaded()
+            && e.Portrait->CharaViewPortraitCharacterLoaded;
+    }
+
     private readonly void AssertValid()
     {
         if (!IsValid)

--- a/Photobooth/Controls/PortraitController.cs
+++ b/Photobooth/Controls/PortraitController.cs
@@ -128,6 +128,10 @@ public class PortraitController : IDisposable
                 progress -= CorrectionFactor(Framework.Instance()->FrameRate);
                 e.ToggleAnimationPlayback(false);
             }
+            else
+            {
+                e.ToggleAnimationPlayback(true);
+            }
 
             e.SetAnimationProgress(progress);
         }

--- a/Photobooth/GameExt/Funcs.cs
+++ b/Photobooth/GameExt/Funcs.cs
@@ -36,11 +36,6 @@ public unsafe class Funcs
         Vector3*,
         uint,
         Vector3*> Character_GetPartPosition;
-
-    [Signature(
-        "40 53 48 83 EC ?? 80 B9 ?? ?? ?? ?? ?? 48 8B D9 74 ?? E8 ?? ?? ?? ?? 41 B8 ?? ?? ?? ?? 48 8D 54 24 ?? 48 8B 48 ?? 48 8B 01 FF 50 ?? 48 8D 4C 24 ?? E8 ?? ?? ?? ?? 45 33 C0"
-    )]
-    public readonly delegate* unmanaged<AtkUnitBase*, void> AgentBannerEditor_Hide2;
 }
 
 public static unsafe class FuncExtensions

--- a/Photobooth/UI/Stateless/ImPB.NudgeFloat.cs
+++ b/Photobooth/UI/Stateless/ImPB.NudgeFloat.cs
@@ -16,7 +16,12 @@ public static partial class ImPB
     /// </summary>
     public static bool NudgeFloat(string label, ref float value, float min, float max, float step)
     {
-        step = ImGui.IsKeyDown(ImGuiKey.ModShift) ? step / 10 : step;
+        var shift = ImGui.IsKeyDown(ImGuiKey.ModShift);
+        var ctrl = ImGui.IsKeyDown(ImGuiKey.ModCtrl);
+        step *=
+            shift ? 0.1f
+            : ctrl ? 10f
+            : 1f;
 
         var repeatMs = 100;
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();


### PR DESCRIPTION
If we're already drawing every frame, we can just check if the banner editor addon has disappeared and toggle ourselves off; no need to hook anything or listen to an event. Likewise we can hide ourselves during the opening process when the CharaViewPortrait (and thus the camera and character position) isn't loaded/stable yet.