### PR TITLE
fix: distinguish manual open & auto open behavior

### DIFF
--- a/Photobooth/Plugin.cs
+++ b/Photobooth/Plugin.cs
@@ -104,7 +104,7 @@ public sealed class Plugin : IDalamudPlugin
     {
         if (Configuration.AutoOpenWhenEditingPortrait && !MainWindow.IsOpen)
         {
-            MainWindow.Toggle();
+            MainWindow.AutoOpen();
         }
     }
 
@@ -128,7 +128,7 @@ public sealed class Plugin : IDalamudPlugin
 
     public void ToggleConfigUI() => ConfigWindow.Toggle();
 
-    public void ToggleMainUI() => MainWindow.Toggle();
+    public void ToggleMainUI() => MainWindow.ForceToggle();
 
     public void ToggleDebugUI() => DebugWindow.Toggle();
 }


### PR DESCRIPTION
The earlier change to delay drawing the main window while the portrait editor was loading accidentally made the dummy/intro/landing page version of the main window never show.

This now distinguishes the "you typed /pb or clicked the 'show main window' button in dalamud" state from the "you have auto-open on and are in the midst of opening the banner editor" state so that we can delay drawing for one but not the other.