### PR TITLE
Snapshot feature

### DIFF
--- a/Photobooth/Controls/PortraitController.cs
+++ b/Photobooth/Controls/PortraitController.cs
@@ -27,6 +27,12 @@ public class PortraitController : IDisposable
         Plugin.SnapshotDataController.StoreCurrentSnapshot(Data, classJobId, id);
     }
 
+    public unsafe uint CurrentClassJobId() {
+        var editor = Editor.Current();
+        if (!editor.IsValid) return 0;
+        return editor.Portrait->PortraitCharacterData.ClassJobId;
+    }
+
     public unsafe void RestoreSnapshot(Guid id)
     {
         if (_snapshot == null)

--- a/Photobooth/Controls/PortraitController.cs
+++ b/Photobooth/Controls/PortraitController.cs
@@ -3,8 +3,8 @@ using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.Sheets;
 using Photobooth.Maths;
+using Photobooth.Model;
 using System;
-using System.Numerics;
 using System.Text.Json;
 
 namespace Photobooth.Controls;
@@ -12,19 +12,11 @@ namespace Photobooth.Controls;
 public class PortraitController : IDisposable
 {
     public ExportedPortraitData Data;
-    private string? _snapshot = null;
 
-    public unsafe void TakeOrUpdateSnapshot(Guid id)
+    public unsafe void TakeSnapshot()
     {
-        Plugin.Log.Warning(Data.Expression.ToString() + " " + Data.CameraTarget.ToString());
-        var classJobId = Editor.Current().Portrait->PortraitCharacterData.ClassJobId;
-        Plugin.Log.Warning(Plugin.PlayerState.Race.Value.Masculine.ToString());
-        Plugin.Log.Warning(Plugin.PlayerState.Sex.ToString());
-        Plugin.Log.Warning(Plugin.PlayerState.Tribe.Value.Masculine.ToString());
-        
-        var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
-        Plugin.Log.Warning($"Class job id: {classJobId}: {classJobName}");
-        Plugin.SnapshotDataController.StoreCurrentSnapshot(Data, classJobId, id);
+        var classJobId = Editor.Current().Portrait->PortraitCharacterData.ClassJobId;        
+        Plugin.SnapshotDataController.StoreCurrentSnapshot(Data, classJobId);
     }
 
     public unsafe uint CurrentClassJobId() {
@@ -33,66 +25,29 @@ public class PortraitController : IDisposable
         return editor.Portrait->PortraitCharacterData.ClassJobId;
     }
 
-    public unsafe void RestoreSnapshot(Guid id)
+    internal unsafe void RestoreSnapshot(PortraitSnapshot snapShot)
     {
-        if (_snapshot == null)
+
+        if (snapShot == null)
         {
             Plugin.Log.Warning("No snapshot to restore");
             return;
         }
 
-        ExportedPortraitData data = JsonSerializer.Deserialize<ExportedPortraitData>(_snapshot, new JsonSerializerOptions
+        ExportedPortraitData data = JsonSerializer.Deserialize<ExportedPortraitData>(snapShot.SerializedSnapshot, new JsonSerializerOptions
         {
             IncludeFields = true,
         });
-        Plugin.Log.Warning($"Restoring data: {JsonSerializer.Serialize(data, new JsonSerializerOptions
-        {
-            IncludeFields = true,
-        })}");
-        Plugin.Log.Warning($"Restoring data: {_snapshot}");
 
-        //_changes = (PortraitChanges)0xFF;
-        Plugin.Log.Warning(_changes.ToString());
-        //Data = data;
         var e = Editor.Current();
         if (!e.IsValid)
         {
             return;
         }
 
-        //var changed = ApplyChanges(e, true);
         var portrait = e.Portrait;
-        //Plugin.Log.Warning("Job selected is " + e.Character->ClassJob);
-        //portrait->SetBackground(Data.BannerBg);
-        //fixed (HalfVector4* cameraPosition = &Data.CameraPosition)
-        //{
-        //    fixed (HalfVector4* cameraTarget = &Data.CameraTarget)
-        //    {
-        //        portrait->SetCameraPosition(cameraPosition, cameraTarget);
+        portrait->ImportPortraitData(&data);
 
-        //    }
-        //}
-
-        //fixed (ExportedPortraitData* pData = &data)
-        //{
-            portrait->ImportPortraitData(&data);
-        //}
-
-
-        //portrait->SetCameraPosition(&Data.CameraPosition, Data.CameraTarget);
-        //this.SetImageRotation(data.ImageRotation);
-
-        //portrait->SetPoseTimed(data.BannerTimeline, data.AnimationProgress);
-
-        //ExportedPortraitData data = System.Text.Json.JsonSerializer.Deserialize<ExportedPortraitData>(_snapshot, new JsonSerializerOptions() { IncludeFields = true });
-        //Plugin.Log.Warning(data.BannerBg.ToString());
-        //Plugin.Log.Warning(_snapshot);
-        //var allFlagsSet = 2 ^ 11 - 1;
-        //_changes = (PortraitChanges)allFlagsSet;
-        //Data.BannerBg = data.BannerBg;
-        //Data = data;
-        //Editor e = Editor.Current();
-        //ApplyChanges(e);
     }
 
     private PortraitChanges _changes = PortraitChanges.None;

--- a/Photobooth/Controls/PortraitController.cs
+++ b/Photobooth/Controls/PortraitController.cs
@@ -1,16 +1,94 @@
-using System;
-using System.Numerics;
 using Dalamud.Plugin.Services;
 using FFXIVClientStructs.FFXIV.Client.System.Framework;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.Sheets;
 using Photobooth.Maths;
+using System;
+using System.Numerics;
+using System.Text.Json;
 
 namespace Photobooth.Controls;
 
 public class PortraitController : IDisposable
 {
     public ExportedPortraitData Data;
+    private string? _snapshot = null;
+
+    public unsafe void TakeSnapshot()
+    {
+        _snapshot = System.Text.Json.JsonSerializer.Serialize(Data, new JsonSerializerOptions
+        {
+            IncludeFields = true
+        });
+        Plugin.Log.Warning(_snapshot);
+        Plugin.Log.Warning(Data.Expression.ToString() + " " + Data.CameraTarget.ToString());
+        var classJobId = Editor.Current().Portrait->PortraitCharacterData.ClassJobId;
+        var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
+        Plugin.Log.Warning($"Class job id: {classJobId}: {classJobName}");
+        SnapshotDataController.StoreCurrentSnapshot(Data, Editor.Current().Portrait->PortraitCharacterData.ClassJobId);
+    }
+
+    public unsafe void RestoreSnapshot()
+    {
+        if (_snapshot == null)
+        {
+            Plugin.Log.Warning("No snapshot to restore");
+            return;
+        }
+
+        ExportedPortraitData data = JsonSerializer.Deserialize<ExportedPortraitData>(_snapshot, new JsonSerializerOptions
+        {
+            IncludeFields = true,
+        });
+        Plugin.Log.Warning($"Restoring data: {JsonSerializer.Serialize(data, new JsonSerializerOptions
+        {
+            IncludeFields = true,
+        })}");
+        Plugin.Log.Warning($"Restoring data: {_snapshot}");
+
+        //_changes = (PortraitChanges)0xFF;
+        Plugin.Log.Warning(_changes.ToString());
+        //Data = data;
+        var e = Editor.Current();
+        if (!e.IsValid)
+        {
+            return;
+        }
+
+        //var changed = ApplyChanges(e, true);
+        var portrait = e.Portrait;
+        //Plugin.Log.Warning("Job selected is " + e.Character->ClassJob);
+        //portrait->SetBackground(Data.BannerBg);
+        //fixed (HalfVector4* cameraPosition = &Data.CameraPosition)
+        //{
+        //    fixed (HalfVector4* cameraTarget = &Data.CameraTarget)
+        //    {
+        //        portrait->SetCameraPosition(cameraPosition, cameraTarget);
+
+        //    }
+        //}
+
+        //fixed (ExportedPortraitData* pData = &data)
+        //{
+            portrait->ImportPortraitData(&data);
+        //}
+
+
+        //portrait->SetCameraPosition(&Data.CameraPosition, Data.CameraTarget);
+        //this.SetImageRotation(data.ImageRotation);
+
+        //portrait->SetPoseTimed(data.BannerTimeline, data.AnimationProgress);
+
+        //ExportedPortraitData data = System.Text.Json.JsonSerializer.Deserialize<ExportedPortraitData>(_snapshot, new JsonSerializerOptions() { IncludeFields = true });
+        //Plugin.Log.Warning(data.BannerBg.ToString());
+        //Plugin.Log.Warning(_snapshot);
+        //var allFlagsSet = 2 ^ 11 - 1;
+        //_changes = (PortraitChanges)allFlagsSet;
+        //Data.BannerBg = data.BannerBg;
+        //Data = data;
+        //Editor e = Editor.Current();
+        //ApplyChanges(e);
+    }
 
     private PortraitChanges _changes = PortraitChanges.None;
 

--- a/Photobooth/Controls/PortraitController.cs
+++ b/Photobooth/Controls/PortraitController.cs
@@ -14,21 +14,16 @@ public class PortraitController : IDisposable
     public ExportedPortraitData Data;
     private string? _snapshot = null;
 
-    public unsafe void TakeSnapshot()
+    public unsafe void TakeOrUpdateSnapshot(Guid id)
     {
-        _snapshot = System.Text.Json.JsonSerializer.Serialize(Data, new JsonSerializerOptions
-        {
-            IncludeFields = true
-        });
-        Plugin.Log.Warning(_snapshot);
         Plugin.Log.Warning(Data.Expression.ToString() + " " + Data.CameraTarget.ToString());
         var classJobId = Editor.Current().Portrait->PortraitCharacterData.ClassJobId;
         var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
         Plugin.Log.Warning($"Class job id: {classJobId}: {classJobName}");
-        SnapshotDataController.StoreCurrentSnapshot(Data, Editor.Current().Portrait->PortraitCharacterData.ClassJobId);
+        Plugin.SnapshotDataController.StoreCurrentSnapshot(Data, classJobId, id);
     }
 
-    public unsafe void RestoreSnapshot()
+    public unsafe void RestoreSnapshot(Guid id)
     {
         if (_snapshot == null)
         {

--- a/Photobooth/Controls/PortraitController.cs
+++ b/Photobooth/Controls/PortraitController.cs
@@ -18,6 +18,10 @@ public class PortraitController : IDisposable
     {
         Plugin.Log.Warning(Data.Expression.ToString() + " " + Data.CameraTarget.ToString());
         var classJobId = Editor.Current().Portrait->PortraitCharacterData.ClassJobId;
+        Plugin.Log.Warning(Plugin.PlayerState.Race.Value.Masculine.ToString());
+        Plugin.Log.Warning(Plugin.PlayerState.Sex.ToString());
+        Plugin.Log.Warning(Plugin.PlayerState.Tribe.Value.Masculine.ToString());
+        
         var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
         Plugin.Log.Warning($"Class job id: {classJobId}: {classJobName}");
         Plugin.SnapshotDataController.StoreCurrentSnapshot(Data, classJobId, id);

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -66,7 +66,7 @@ namespace Photobooth.Controls
             var existing = snapshots[classJobId].FirstOrDefault(snapshot => snapshot.Id == id);
             if (existing == null)
             {
-                var newSnapshot = new PortraitSnapshot(classJobId, classJobName, sexText, raceText, tribeText, serializedSnapshotData);
+                var newSnapshot = new PortraitSnapshot(classJobId, classJobName, raceText, tribeText, sexText, serializedSnapshotData);
                 snapshots[classJobId].Add(newSnapshot);
                 Plugin.Log.Info($"Portrait for job {classJobName} created: {serializedSnapshotData}");
 

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -21,7 +21,8 @@ namespace Photobooth.Controls
         private string _filePath = Path.Combine(Plugin.PluginInterface.ConfigDirectory.FullName, FileName);
         private Dictionary<uint, List<PortraitSnapshot>> _snapshotsInternal = new Dictionary<uint, List<PortraitSnapshot>>();
         private bool _snapshotsAreLoaded = false;
-        public Dictionary<uint, List<PortraitSnapshot>> Snapshots
+
+        internal Dictionary<uint, List<PortraitSnapshot>> Snapshots
         {
             get
             {
@@ -35,12 +36,12 @@ namespace Photobooth.Controls
             }
         }
 
-        public void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId)
+        internal void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId)
         {
             StoreCurrentSnapshot(data, classJobId, Guid.Empty);
         }
 
-        public unsafe void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId, Guid id)
+        internal void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId, Guid id)
         {
             Plugin.Log.Warning("Storing current snapshot");
             var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -1,0 +1,23 @@
+using Dalamud.Interface;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using Lumina.Excel.Sheets;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Photobooth.Controls
+{
+    internal static class SnapshotDataController
+    {
+        private const string FileName = "Snapshots.json";
+        public static unsafe void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId)
+        {
+            var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
+            var dateTime = DateTime.Now;
+            var filePath = Path.Combine(Plugin.PluginInterface.ConfigDirectory.FullName, FileName);
+            Plugin.Log.Warning(filePath);
+
+        }
+    }
+}

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -43,7 +43,7 @@ namespace Photobooth.Controls
 
         internal void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId, Guid id)
         {
-            Plugin.Log.Warning("Storing current snapshot");
+            Plugin.Log.Info("Storing current snapshot");
             var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
             var serializedSnapshotData = System.Text.Json.JsonSerializer.Serialize(data, new JsonSerializerOptions
             {
@@ -55,7 +55,7 @@ namespace Photobooth.Controls
             var raceText = sex == Sex.Male ? Plugin.PlayerState.Race.Value.Masculine.ToString() : Plugin.PlayerState.Race.Value.Feminine.ToString();
             var tribeText = sex == Sex.Male ? Plugin.PlayerState.Tribe.Value.Masculine.ToString() : Plugin.PlayerState.Tribe.Value.Feminine.ToString();
             var snapshots = Snapshots;
-            Plugin.Log.Warning($"Data to save: {serializedSnapshotData}");
+            Plugin.Log.Debug($"Data to save: {serializedSnapshotData}");
 
             if (!snapshots.ContainsKey(classJobId))
             {

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -1,5 +1,4 @@
 using Dalamud.Game.Player;
-using Dalamud.Interface;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.Sheets;
 using Photobooth.Model;
@@ -7,9 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace Photobooth.Controls
 {
@@ -24,7 +21,9 @@ namespace Photobooth.Controls
         private string _filePath = Path.Combine(Plugin.PluginInterface.ConfigDirectory.FullName, FileName);
         private Dictionary<uint, List<PortraitSnapshot>> _snapshotsInternal = new Dictionary<uint, List<PortraitSnapshot>>();
         private bool _snapshotsAreLoaded = false;
-        public Dictionary<uint, List<PortraitSnapshot>> Snapshots { get
+        public Dictionary<uint, List<PortraitSnapshot>> Snapshots
+        {
+            get
             {
                 if (!_snapshotsAreLoaded)
                 {
@@ -33,9 +32,8 @@ namespace Photobooth.Controls
                 }
 
                 return _snapshotsInternal;
-            } }
-
-
+            }
+        }
 
         public void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId)
         {

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -27,6 +27,7 @@ namespace Photobooth.Controls
             {
                 if (!_snapshotsAreLoaded)
                 {
+                    Plugin.Log.Info("Snapshots loaded");
                     LoadSnapshots();
                 }
 
@@ -35,8 +36,14 @@ namespace Photobooth.Controls
 
 
 
+        public void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId)
+        {
+            StoreCurrentSnapshot(data, classJobId, Guid.Empty);
+        }
+
         public unsafe void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId, Guid id)
         {
+            Plugin.Log.Warning("Storing current snapshot");
             var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
             var serializedSnapshotData = System.Text.Json.JsonSerializer.Serialize(data, new JsonSerializerOptions
             {
@@ -44,6 +51,8 @@ namespace Photobooth.Controls
             });
 
             var snapshots = Snapshots;
+            Plugin.Log.Warning($"Data to save: {serializedSnapshotData}");
+
             if (!snapshots.ContainsKey(classJobId))
             {
                 snapshots[classJobId] = new List<PortraitSnapshot>();
@@ -63,6 +72,8 @@ namespace Photobooth.Controls
                 existing.SerializedSnapshot = serializedSnapshotData;
                 Plugin.Log.Info($"Portrait for job {classJobName} updated: {serializedSnapshotData}");
             }
+
+            File.WriteAllText(_filePath, JsonSerializer.Serialize(snapshots));
         }
 
         private Dictionary<uint, List<PortraitSnapshot>> LoadSnapshots()

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -1,23 +1,87 @@
 using Dalamud.Interface;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.Sheets;
+using Photobooth.Model;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Photobooth.Controls
 {
-    internal static class SnapshotDataController
+    internal class SnapshotDataController
     {
+        private static readonly JsonSerializerOptions _SerializerOptions = new JsonSerializerOptions
+        {
+            IncludeFields = true
+        };
+
         private const string FileName = "Snapshots.json";
-        public static unsafe void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId)
+        private string _filePath = Path.Combine(Plugin.PluginInterface.ConfigDirectory.FullName, FileName);
+        private Dictionary<uint, List<PortraitSnapshot>> _snapshotsInternal = new Dictionary<uint, List<PortraitSnapshot>>();
+        private bool _snapshotsAreLoaded = false;
+        public Dictionary<uint, List<PortraitSnapshot>> Snapshots { get
+            {
+                if (!_snapshotsAreLoaded)
+                {
+                    LoadSnapshots();
+                }
+
+                return _snapshotsInternal;
+            } }
+
+
+
+        public unsafe void StoreCurrentSnapshot(ExportedPortraitData data, uint classJobId, Guid id)
         {
             var classJobName = Plugin.DataManager.GetExcelSheet<ClassJob>().GetRow(classJobId).NameEnglish.ToString();
-            var dateTime = DateTime.Now;
-            var filePath = Path.Combine(Plugin.PluginInterface.ConfigDirectory.FullName, FileName);
-            Plugin.Log.Warning(filePath);
+            var serializedSnapshotData = System.Text.Json.JsonSerializer.Serialize(data, new JsonSerializerOptions
+            {
+                IncludeFields = true
+            });
 
+            var snapshots = Snapshots;
+            if (!snapshots.ContainsKey(classJobId))
+            {
+                snapshots[classJobId] = new List<PortraitSnapshot>();
+            }
+
+            var existing = snapshots[classJobId].FirstOrDefault(snapshot => snapshot.Id == id);
+            if (existing == null)
+            {
+                var newSnapshot = new PortraitSnapshot(classJobId, classJobName, serializedSnapshotData);
+                snapshots[classJobId].Add(newSnapshot);
+                Plugin.Log.Info($"Portrait for job {classJobName} created: {serializedSnapshotData}");
+
+            }
+            else
+            {                
+                existing.TakenAt = DateTime.Now;
+                existing.SerializedSnapshot = serializedSnapshotData;
+                Plugin.Log.Info($"Portrait for job {classJobName} updated: {serializedSnapshotData}");
+            }
+        }
+
+        private Dictionary<uint, List<PortraitSnapshot>> LoadSnapshots()
+        {
+            if (!File.Exists(_filePath))
+            {
+                Plugin.Log.Info("Snapshot file created");
+                File.WriteAllText(_filePath, JsonSerializer.Serialize(_snapshotsInternal, _SerializerOptions));
+            }
+            else
+            {
+                var serialized = File.ReadAllText(_filePath);
+                _snapshotsInternal = JsonSerializer.Deserialize<Dictionary<uint, List<PortraitSnapshot>>>(serialized) ?? new();
+                Plugin.Log.Info($"Snapshots file loaded");
+            }
+            
+            _snapshotsAreLoaded = true;
+
+            return _snapshotsInternal;
         }
     }
 }

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -66,6 +66,7 @@ namespace Photobooth.Controls
             if (existing == null)
             {
                 var newSnapshot = new PortraitSnapshot(classJobId, classJobName, raceText, tribeText, sexText, serializedSnapshotData);
+                Plugin.Log.Info($"Creating snapshot: Job: {classJobName} Race: {raceText} Tribe: {tribeText} Sex: {sexText}");
                 snapshots[classJobId].Add(newSnapshot);
                 Plugin.Log.Info($"Portrait for job {classJobName} created: {serializedSnapshotData}");
 

--- a/Photobooth/Controls/SnapshotDataController.cs
+++ b/Photobooth/Controls/SnapshotDataController.cs
@@ -1,3 +1,4 @@
+using Dalamud.Game.Player;
 using Dalamud.Interface;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.Sheets;
@@ -50,6 +51,10 @@ namespace Photobooth.Controls
                 IncludeFields = true
             });
 
+            Sex sex = Plugin.PlayerState.Sex;
+            var sexText = Plugin.PlayerState.Sex.ToString();
+            var raceText = sex == Sex.Male ? Plugin.PlayerState.Race.Value.Masculine.ToString() : Plugin.PlayerState.Race.Value.Feminine.ToString();
+            var tribeText = sex == Sex.Male ? Plugin.PlayerState.Tribe.Value.Masculine.ToString() : Plugin.PlayerState.Tribe.Value.Feminine.ToString();
             var snapshots = Snapshots;
             Plugin.Log.Warning($"Data to save: {serializedSnapshotData}");
 
@@ -61,7 +66,7 @@ namespace Photobooth.Controls
             var existing = snapshots[classJobId].FirstOrDefault(snapshot => snapshot.Id == id);
             if (existing == null)
             {
-                var newSnapshot = new PortraitSnapshot(classJobId, classJobName, serializedSnapshotData);
+                var newSnapshot = new PortraitSnapshot(classJobId, classJobName, sexText, raceText, tribeText, serializedSnapshotData);
                 snapshots[classJobId].Add(newSnapshot);
                 Plugin.Log.Info($"Portrait for job {classJobName} created: {serializedSnapshotData}");
 

--- a/Photobooth/Model/PortraitSnapshot.cs
+++ b/Photobooth/Model/PortraitSnapshot.cs
@@ -15,11 +15,20 @@ namespace Photobooth.Model
 
         public string SerializedSnapshot { get; set;  }
 
-        public PortraitSnapshot(uint classJobId, string classJobName, string serializedSnapshot)
+        public string Race { get; set; }
+
+        public string TribeName { get; set; }
+
+        public string Gender { get; set; }
+
+        public PortraitSnapshot(uint classJobId, string classJobName, string race, string tribeName, string gender, string serializedSnapshot)
         {
             TakenAt = DateTime.Now;
             ClassJobId = classJobId;
             ClassJobName = classJobName;
+            Race = race;
+            TribeName = tribeName;
+            Gender = gender;
             SerializedSnapshot = serializedSnapshot;
         }
     }

--- a/Photobooth/Model/PortraitSnapshot.cs
+++ b/Photobooth/Model/PortraitSnapshot.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Photobooth.Model
+{
+    internal class PortraitSnapshot
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+
+        public DateTime TakenAt { get; set; }
+        public uint ClassJobId { get; set; }
+
+        public string ClassJobName { get; set; }
+
+        public string SerializedSnapshot { get; set;  }
+
+        public PortraitSnapshot(uint classJobId, string classJobName, string serializedSnapshot)
+        {
+            TakenAt = DateTime.Now;
+            ClassJobId = classJobId;
+            ClassJobName = classJobName;
+            SerializedSnapshot = serializedSnapshot;
+        }
+    }
+}

--- a/Photobooth/Model/PortraitSnapshot.cs
+++ b/Photobooth/Model/PortraitSnapshot.cs
@@ -19,16 +19,16 @@ namespace Photobooth.Model
 
         public string TribeName { get; set; }
 
-        public string Gender { get; set; }
+        public string Sex { get; set; }
 
-        public PortraitSnapshot(uint classJobId, string classJobName, string race, string tribeName, string gender, string serializedSnapshot)
+        public PortraitSnapshot(uint classJobId, string classJobName, string race, string tribeName, string sex, string serializedSnapshot)
         {
             TakenAt = DateTime.Now;
             ClassJobId = classJobId;
             ClassJobName = classJobName;
             Race = race;
             TribeName = tribeName;
-            Gender = gender;
+            Sex = sex;
             SerializedSnapshot = serializedSnapshot;
         }
     }

--- a/Photobooth/Plugin.cs
+++ b/Photobooth/Plugin.cs
@@ -5,6 +5,7 @@ using Dalamud.Interface.Windowing;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
+using Photobooth.Controls;
 using Photobooth.Windows;
 
 namespace Photobooth;
@@ -47,6 +48,9 @@ public sealed class Plugin : IDalamudPlugin
     public Configuration Configuration { get; init; }
 
     public readonly WindowSystem WindowSystem = new($"{PluginName}Plugin");
+
+    internal static SnapshotDataController SnapshotDataController { get; private set; }
+
     private ConfigWindow ConfigWindow { get; init; }
     private MainWindow MainWindow { get; init; }
     private DebugWindow DebugWindow { get; init; }
@@ -63,6 +67,7 @@ public sealed class Plugin : IDalamudPlugin
         WindowSystem.AddWindow(MainWindow);
         WindowSystem.AddWindow(DebugWindow);
 
+        SnapshotDataController = new SnapshotDataController();
         CommandManager.AddHandler(
             CommandName,
             new CommandInfo(OnCommand)

--- a/Photobooth/Plugin.cs
+++ b/Photobooth/Plugin.cs
@@ -45,6 +45,9 @@ public sealed class Plugin : IDalamudPlugin
     [PluginService]
     internal static IFramework Framework { get; private set; } = null!;
 
+    [PluginService]
+    internal static IPlayerState PlayerState { get; private set; } = null!;
+
     public Configuration Configuration { get; init; }
 
     public readonly WindowSystem WindowSystem = new($"{PluginName}Plugin");

--- a/Photobooth/UI/Panels/SnapshotPanel.cs
+++ b/Photobooth/UI/Panels/SnapshotPanel.cs
@@ -1,11 +1,9 @@
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
+using Dalamud.Interface.Components;
 using Photobooth.Controls;
 using Photobooth.Model;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace Photobooth.UI.Panels
 {
@@ -17,10 +15,7 @@ namespace Photobooth.UI.Panels
         protected override void DrawBody()
         {
 
-            if (ImGui.Button("Take snapshot"))
-            {
-                _portrait.TakeOrUpdateSnapshot(Guid.NewGuid());
-            }
+
             var snapshots = Plugin.SnapshotDataController.Snapshots;
             var currentClassJobId = _portrait.CurrentClassJobId();
             if (snapshots.ContainsKey(currentClassJobId))
@@ -28,10 +23,13 @@ namespace Photobooth.UI.Panels
                 DrawSnapshopTable(snapshots[currentClassJobId]);
             }
 
-            if (ImGui.Button("Restore snapshot"))
+            if (ImGui.Button("Take snapshot"))
             {
-                var guid = Guid.NewGuid(); //temporary
-                _portrait.RestoreSnapshot(guid);
+                _portrait.TakeSnapshot();
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.SetTooltip("Save the current look of the portrait. Border and accent are not saved.");
             }
         }
 
@@ -40,15 +38,16 @@ namespace Photobooth.UI.Panels
             if (ImGui.BeginTable("Saved snapshots", 4, ImGuiTableFlags.Resizable))
             {
                 
-                ImGui.TableSetupColumn("Date", ImGuiTableColumnFlags.WidthStretch, 0.2f);
-                ImGui.TableSetupColumn("Clan", ImGuiTableColumnFlags.WidthStretch, 0.7f);
-                ImGui.TableSetupColumn("Gender", ImGuiTableColumnFlags.WidthStretch, 0.1f);
-                ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthStretch, 0.3f);
+                ImGui.TableSetupColumn("Date", ImGuiTableColumnFlags.WidthStretch, 0.3f);
+                ImGui.TableSetupColumn("Clan", ImGuiTableColumnFlags.WidthStretch, 0.4f);
+                ImGui.TableSetupColumn("Gender", ImGuiTableColumnFlags.WidthStretch, 0.2f);
+                ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthStretch, 0.1f);
                 ImGui.TableHeadersRow();
 
                 ImGui.TableNextRow();
                 ImGui.TableNextColumn();
                 var currentClassJobIdd = _portrait.CurrentClassJobId();
+                int index = 0;
                 foreach (var snapshot in snaps)
                 {
                     ImGui.TableNextRow();
@@ -59,7 +58,15 @@ namespace Photobooth.UI.Panels
                     ImGui.TableNextColumn();
                     ImGui.TextUnformatted(snapshot.Gender);
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted("buttons");
+                    if (ImGuiComponents.IconButton($"Apply##{index}", FontAwesomeIcon.ArrowsSpin))
+                    {
+                        _portrait.RestoreSnapshot(snapshot);
+                    }
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.SetTooltip("Apply saved snapshot to the portrait.");
+                    }
+                    index++;
                 }
 
                 ImGui.EndTable();

--- a/Photobooth/UI/Panels/SnapshotPanel.cs
+++ b/Photobooth/UI/Panels/SnapshotPanel.cs
@@ -1,0 +1,28 @@
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Photobooth.Controls;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Photobooth.UI.Panels
+{
+    internal class SnapshotPanel(PortraitController portrait)
+        : Panel(FontAwesomeIcon.PhotoVideo, "Saved snapshots for this job")
+    {
+        private readonly PortraitController _portrait = portrait;
+
+        protected override void DrawBody()
+        {
+
+            if (ImGui.Button("Take snapshot"))
+            {
+                _portrait.TakeSnapshot();
+            }
+            if (ImGui.Button("Restore snapshot"))
+            {
+                _portrait.RestoreSnapshot();
+            }
+        }
+    }
+}

--- a/Photobooth/UI/Panels/SnapshotPanel.cs
+++ b/Photobooth/UI/Panels/SnapshotPanel.cs
@@ -1,8 +1,10 @@
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Photobooth.Controls;
+using Photobooth.Model;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace Photobooth.UI.Panels
@@ -19,10 +21,49 @@ namespace Photobooth.UI.Panels
             {
                 _portrait.TakeOrUpdateSnapshot(Guid.NewGuid());
             }
+            var snapshots = Plugin.SnapshotDataController.Snapshots;
+            var currentClassJobId = _portrait.CurrentClassJobId();
+            if (snapshots.ContainsKey(currentClassJobId))
+            {
+                DrawSnapshopTable(snapshots[currentClassJobId]);
+            }
+
             if (ImGui.Button("Restore snapshot"))
             {
                 var guid = Guid.NewGuid(); //temporary
                 _portrait.RestoreSnapshot(guid);
+            }
+        }
+
+        private void DrawSnapshopTable(List<PortraitSnapshot> snaps)
+        {
+            if (ImGui.BeginTable("Saved snapshots", 4, ImGuiTableFlags.Resizable))
+            {
+                
+                ImGui.TableSetupColumn("Date", ImGuiTableColumnFlags.WidthStretch, 0.2f);
+                ImGui.TableSetupColumn("Clan", ImGuiTableColumnFlags.WidthStretch, 0.7f);
+                ImGui.TableSetupColumn("Gender", ImGuiTableColumnFlags.WidthStretch, 0.1f);
+                ImGui.TableSetupColumn("Actions", ImGuiTableColumnFlags.WidthStretch, 0.3f);
+                ImGui.TableHeadersRow();
+
+                ImGui.TableNextRow();
+                ImGui.TableNextColumn();
+                var currentClassJobIdd = _portrait.CurrentClassJobId();
+                foreach (var snapshot in snaps)
+                {
+                    ImGui.TableNextRow();
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted($"{snapshot.TakenAt.ToShortDateString()} {snapshot.TakenAt.ToShortTimeString()}");
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted(snapshot.TribeName);
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted(snapshot.Gender);
+                    ImGui.TableNextColumn();
+                    ImGui.TextUnformatted("buttons");
+                }
+
+                ImGui.EndTable();
+
             }
         }
     }

--- a/Photobooth/UI/Panels/SnapshotPanel.cs
+++ b/Photobooth/UI/Panels/SnapshotPanel.cs
@@ -14,8 +14,6 @@ namespace Photobooth.UI.Panels
 
         protected override void DrawBody()
         {
-
-
             var snapshots = Plugin.SnapshotDataController.Snapshots;
             var currentClassJobId = _portrait.CurrentClassJobId();
             if (snapshots.ContainsKey(currentClassJobId))
@@ -37,7 +35,6 @@ namespace Photobooth.UI.Panels
         {
             if (ImGui.BeginTable("Saved snapshots", 4, ImGuiTableFlags.Resizable))
             {
-                
                 ImGui.TableSetupColumn("Date", ImGuiTableColumnFlags.WidthStretch, 0.3f);
                 ImGui.TableSetupColumn("Clan", ImGuiTableColumnFlags.WidthStretch, 0.4f);
                 ImGui.TableSetupColumn("Gender", ImGuiTableColumnFlags.WidthStretch, 0.2f);
@@ -56,7 +53,7 @@ namespace Photobooth.UI.Panels
                     ImGui.TableNextColumn();
                     ImGui.TextUnformatted(snapshot.TribeName);
                     ImGui.TableNextColumn();
-                    ImGui.TextUnformatted(snapshot.Gender);
+                    ImGui.TextUnformatted(snapshot.Sex);
                     ImGui.TableNextColumn();
                     if (ImGuiComponents.IconButton($"Apply##{index}", FontAwesomeIcon.ArrowsSpin))
                     {
@@ -70,7 +67,6 @@ namespace Photobooth.UI.Panels
                 }
 
                 ImGui.EndTable();
-
             }
         }
     }

--- a/Photobooth/UI/Panels/SnapshotPanel.cs
+++ b/Photobooth/UI/Panels/SnapshotPanel.cs
@@ -17,11 +17,12 @@ namespace Photobooth.UI.Panels
 
             if (ImGui.Button("Take snapshot"))
             {
-                _portrait.TakeSnapshot();
+                _portrait.TakeOrUpdateSnapshot(Guid.NewGuid());
             }
             if (ImGui.Button("Restore snapshot"))
             {
-                _portrait.RestoreSnapshot();
+                var guid = Guid.NewGuid(); //temporary
+                _portrait.RestoreSnapshot(guid);
             }
         }
     }

--- a/Photobooth/Windows/MainWindow.cs
+++ b/Photobooth/Windows/MainWindow.cs
@@ -24,6 +24,7 @@ public class MainWindow : Window, IDisposable
     private readonly CameraPanel _cameraPanel;
     private readonly FacingPanel _facingPanel;
     private readonly LightingPanel _lightingPanel;
+    private readonly SnapshotPanel _snapshotPanel;
 
     // The temporary/stateful attachment side of the window, so "auto" doesn't
     // flip sides when moving the banner editor unless there's no more space.
@@ -71,6 +72,7 @@ public class MainWindow : Window, IDisposable
         _cameraPanel = new CameraPanel(_portrait, _camera, _plugin.Configuration);
         _facingPanel = new FacingPanel(_portrait, _plugin.Configuration);
         _lightingPanel = new LightingPanel(_portrait);
+        _snapshotPanel = new SnapshotPanel(_portrait);
     }
 
     public void Dispose()
@@ -86,6 +88,7 @@ public class MainWindow : Window, IDisposable
         _cameraPanel.Reset();
         _facingPanel.Reset();
         _lightingPanel.Reset();
+        _snapshotPanel.Reset();
     }
 
     public void AutoOpen()
@@ -206,6 +209,7 @@ public class MainWindow : Window, IDisposable
         _animationPanel.Draw();
         _cameraPanel.Draw();
         _facingPanel.Draw();
+        _snapshotPanel.Draw();
     }
 
     private unsafe void Unopened()


### PR DESCRIPTION
This PR adds a feature that allows users to take a "snapshot" of the portrait, and restoring that snapshot with one click. This is intended for both backing up your favorite portraits before changing them, and restoring portraits in case you fantasia for a moment.
Thinking of this as an archive, I opted to not implement snapshot updating or removal. The JSON they're stored in can be modified manually though.

Accents and frames are not restored, but backgrounds are. I do not know a workaround for this limitation.
<img width="699" height="272" alt="image" src="https://github.com/user-attachments/assets/bac1628f-a321-4cd5-b980-db19d7df06ac" />
