### PR TITLE
Add portrait settings clipboard import/export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs/
+.idea/
 obj/
 bin/
 *.user

--- a/Photobooth/Controls/CameraController.cs
+++ b/Photobooth/Controls/CameraController.cs
@@ -143,6 +143,16 @@ internal class CameraController
         Subject = Vector3.Zero;
     }
 
+    public void Import(PortraitClipboard.CameraClipboardSettings settings)
+    {
+        Builtin.SetPivot(settings.Pivot);
+        Builtin.SetDistance(settings.Distance);
+        Builtin.SetDirection(settings.Direction);
+        Builtin.SetZoom(settings.Zoom);
+
+        RecomputeCustom();
+    }
+
     public void SetZoom(byte zoom)
     {
         Builtin.SetZoom(zoom);

--- a/Photobooth/Controls/PortraitClipboard.cs
+++ b/Photobooth/Controls/PortraitClipboard.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using Photobooth.Maths;
+
+namespace Photobooth.Controls;
+
+internal static class PortraitClipboard
+{
+    private const string Prefix = "PhotoboothPortrait:v1:";
+
+    public static string Export(PortraitController portrait, CameraController camera)
+    {
+        var settings = PortraitClipboardSettings.From(portrait.Data, camera);
+        var json = JsonSerializer.Serialize(settings);
+        return Prefix + Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
+    }
+
+    public static bool TryImport(
+        string text,
+        PortraitController portrait,
+        CameraController camera,
+        out string message
+    )
+    {
+        message = string.Empty;
+
+        if (!text.StartsWith(Prefix, StringComparison.Ordinal))
+        {
+            message = "Clipboard does not contain Photobooth portrait settings.";
+            return false;
+        }
+
+        try
+        {
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(text[Prefix.Length..]));
+            var settings = JsonSerializer.Deserialize<PortraitClipboardSettings>(json);
+            if (settings == null || settings.Version != 1)
+            {
+                message = "Unsupported Photobooth portrait settings version.";
+                return false;
+            }
+
+            portrait.Import(settings);
+            camera.Import(settings.Camera);
+            message = "Portrait settings pasted.";
+            return true;
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException or ArgumentException)
+        {
+            message = "Could not read Photobooth portrait settings from clipboard.";
+            return false;
+        }
+    }
+
+    internal sealed class PortraitClipboardSettings
+    {
+        public int Version { get; set; } = 1;
+
+        public int BannerTimeline { get; set; }
+        public float AnimationProgress { get; set; }
+        public int Expression { get; set; }
+
+        public float HeadX { get; set; }
+        public float HeadY { get; set; }
+        public float EyeX { get; set; }
+        public float EyeY { get; set; }
+
+        public byte AmbientRed { get; set; }
+        public byte AmbientGreen { get; set; }
+        public byte AmbientBlue { get; set; }
+        public byte AmbientBrightness { get; set; }
+
+        public byte DirectionalRed { get; set; }
+        public byte DirectionalGreen { get; set; }
+        public byte DirectionalBlue { get; set; }
+        public byte DirectionalBrightness { get; set; }
+        public short DirectionalVerticalAngle { get; set; }
+        public short DirectionalHorizontalAngle { get; set; }
+
+        public short ImageRotation { get; set; }
+        public byte CameraZoom { get; set; }
+        public CameraClipboardSettings Camera { get; set; } = new();
+
+        public static PortraitClipboardSettings From(
+            FFXIVClientStructs.FFXIV.Client.UI.Misc.ExportedPortraitData data,
+            CameraController camera
+        )
+        {
+            return new PortraitClipboardSettings
+            {
+                BannerTimeline = data.BannerTimeline,
+                AnimationProgress = data.AnimationProgress,
+                Expression = data.Expression,
+                HeadX = (float)data.HeadDirection.X,
+                HeadY = (float)data.HeadDirection.Y,
+                EyeX = (float)data.EyeDirection.X,
+                EyeY = (float)data.EyeDirection.Y,
+                AmbientRed = data.AmbientLightingColorRed,
+                AmbientGreen = data.AmbientLightingColorGreen,
+                AmbientBlue = data.AmbientLightingColorBlue,
+                AmbientBrightness = data.AmbientLightingBrightness,
+                DirectionalRed = data.DirectionalLightingColorRed,
+                DirectionalGreen = data.DirectionalLightingColorGreen,
+                DirectionalBlue = data.DirectionalLightingColorBlue,
+                DirectionalBrightness = data.DirectionalLightingBrightness,
+                DirectionalVerticalAngle = data.DirectionalLightingVerticalAngle,
+                DirectionalHorizontalAngle = data.DirectionalLightingHorizontalAngle,
+                ImageRotation = data.ImageRotation,
+                CameraZoom = data.CameraZoom,
+                Camera = CameraClipboardSettings.From(camera),
+            };
+        }
+    }
+
+    internal sealed class CameraClipboardSettings
+    {
+        public float PivotX { get; set; }
+        public float PivotY { get; set; }
+        public float PivotZ { get; set; }
+        public float Distance { get; set; }
+        public float Pitch { get; set; }
+        public float Yaw { get; set; }
+        public byte Zoom { get; set; }
+
+        public static CameraClipboardSettings From(CameraController camera)
+        {
+            return new CameraClipboardSettings
+            {
+                PivotX = camera.Pivot.X,
+                PivotY = camera.Pivot.Y,
+                PivotZ = camera.Pivot.Z,
+                Distance = camera.Distance,
+                Pitch = camera.Direction.LatRadians,
+                Yaw = camera.Direction.LonRadians,
+                Zoom = camera.Zoom,
+            };
+        }
+
+        public Vector3 Pivot => new(PivotX, PivotY, PivotZ);
+
+        public SphereLL Direction => SphereLL.FromRadians(Pitch, Yaw);
+    }
+}

--- a/Photobooth/Controls/PortraitController.cs
+++ b/Photobooth/Controls/PortraitController.cs
@@ -107,6 +107,49 @@ public class PortraitController : IDisposable
         return _changes != PortraitChanges.None;
     }
 
+    internal void Import(PortraitClipboard.PortraitClipboardSettings settings)
+    {
+        Data.BannerTimeline = (ushort)settings.BannerTimeline;
+        Data.AnimationProgress = settings.AnimationProgress;
+        Data.Expression = (byte)settings.Expression;
+
+        Data.HeadDirection.X = (Half)settings.HeadX;
+        Data.HeadDirection.Y = (Half)settings.HeadY;
+        Data.EyeDirection.X = (Half)settings.EyeX;
+        Data.EyeDirection.Y = (Half)settings.EyeY;
+
+        Data.AmbientLightingColorRed = settings.AmbientRed;
+        Data.AmbientLightingColorGreen = settings.AmbientGreen;
+        Data.AmbientLightingColorBlue = settings.AmbientBlue;
+        Data.AmbientLightingBrightness = ClampBrightness(settings.AmbientBrightness);
+
+        Data.DirectionalLightingColorRed = settings.DirectionalRed;
+        Data.DirectionalLightingColorGreen = settings.DirectionalGreen;
+        Data.DirectionalLightingColorBlue = settings.DirectionalBlue;
+        Data.DirectionalLightingBrightness = ClampBrightness(settings.DirectionalBrightness);
+        Data.DirectionalLightingVerticalAngle = settings.DirectionalVerticalAngle;
+        Data.DirectionalLightingHorizontalAngle = settings.DirectionalHorizontalAngle;
+
+        Data.ImageRotation = Math.Clamp(
+            settings.ImageRotation,
+            CameraConsts.RotationMin,
+            CameraConsts.RotationMax
+        );
+        Data.CameraZoom = Math.Clamp(settings.CameraZoom, CameraConsts.ZoomMin, CameraConsts.ZoomMax);
+
+        _changes =
+            PortraitChanges.AmbientLightColor
+            | PortraitChanges.DirectionalLightColor
+            | PortraitChanges.DirectionalLightDirection
+            | PortraitChanges.EyeDirection
+            | PortraitChanges.HeadDirection
+            | PortraitChanges.CameraZoom
+            | PortraitChanges.ImageRotation
+            | PortraitChanges.Pose
+            | PortraitChanges.Expression
+            | PortraitChanges.AnimationProgress;
+    }
+
     /// <summary>
     /// Apply changes to a CharaViewPortrait, somewhat delicately.
     /// </summary>

--- a/Photobooth/UI/Panels/ClipboardPanel.cs
+++ b/Photobooth/UI/Panels/ClipboardPanel.cs
@@ -1,0 +1,51 @@
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface;
+using Photobooth.Controls;
+
+namespace Photobooth.UI.Panels;
+
+internal class ClipboardPanel(PortraitController portrait, CameraController camera)
+    : Panel(FontAwesomeIcon.Clipboard, "Clipboard")
+{
+    private readonly PortraitController _portrait = portrait;
+    private readonly CameraController _camera = camera;
+
+    private string _status = string.Empty;
+
+    protected override void DrawBody()
+    {
+        var e = Editor.Current();
+        if (!e.IsValid)
+        {
+            return;
+        }
+
+        var buttonWidth = (ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X) / 2;
+
+        if (ImGui.Button("Copy Settings", new(buttonWidth, 0)))
+        {
+            ImGui.SetClipboardText(PortraitClipboard.Export(_portrait, _camera));
+            _status = "Portrait settings copied.";
+        }
+
+        ImGui.SameLine();
+
+        if (ImGui.Button("Paste Settings", new(buttonWidth, 0)))
+        {
+            if (PortraitClipboard.TryImport(ImGui.GetClipboardText(), _portrait, _camera, out var message))
+            {
+                _portrait.ApplyChanges(e);
+                _camera.Save(e);
+                e.SetHasChanged(true);
+                e.UpdateUI(in _portrait.Data);
+            }
+
+            _status = message;
+        }
+
+        if (!string.IsNullOrEmpty(_status))
+        {
+            ImGui.TextWrapped(_status);
+        }
+    }
+}

--- a/Photobooth/Windows/MainWindow.cs
+++ b/Photobooth/Windows/MainWindow.cs
@@ -24,6 +24,7 @@ public class MainWindow : Window, IDisposable
     private readonly CameraPanel _cameraPanel;
     private readonly FacingPanel _facingPanel;
     private readonly LightingPanel _lightingPanel;
+    private readonly ClipboardPanel _clipboardPanel;
 
     // The temporary/stateful attachment side of the window, so "auto" doesn't
     // flip sides when moving the banner editor unless there's no more space.
@@ -71,6 +72,7 @@ public class MainWindow : Window, IDisposable
         _cameraPanel = new CameraPanel(_portrait, _camera, _plugin.Configuration);
         _facingPanel = new FacingPanel(_portrait, _plugin.Configuration);
         _lightingPanel = new LightingPanel(_portrait);
+        _clipboardPanel = new ClipboardPanel(_portrait, _camera);
     }
 
     public void Dispose()
@@ -206,6 +208,7 @@ public class MainWindow : Window, IDisposable
         _animationPanel.Draw();
         _cameraPanel.Draw();
         _facingPanel.Draw();
+        _clipboardPanel.Draw();
     }
 
     private unsafe void Unopened()


### PR DESCRIPTION
Adds clipboard import/export support for portrait settings, allowing easy sharing and reusable presets.


Kept the UI simple and unobtrusive. Feel free to style it further to match your style:

<img width="412" height="126" alt="image" src="https://github.com/user-attachments/assets/8f6e310e-6046-4cc5-886b-65c84c9f08d8" />

Example export string:

> `PhotoboothPortrait:v1:eyJWZXJzaW9uIjoxLCJCYW5u...LTFLjI0OTc0MTEsIlpvb20iOjEzNX19`